### PR TITLE
Support for Laravel 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "hammerstone/sidecar": "v0.3.5",
+        "hammerstone/sidecar": "v0.3.9",
         "inertiajs/inertia-laravel": "^0.5.1",
         "illuminate/support": "^8.0|^9.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.2|^8.0",
         "hammerstone/sidecar": "v0.3.5",
         "inertiajs/inertia-laravel": "^0.5.1",
-        "illuminate/support": "^8.0"
+        "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0|^6.0",


### PR DESCRIPTION
I think we could get away with just using the `config()` function as this is meant to be used with Laravel anyway... and require testbench for dev and testing.