### PR TITLE
Update Sidecar and Inertia requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "hammerstone/sidecar": "v0.3.9",
+        "hammerstone/sidecar": "^0.3.9",
         "inertiajs/inertia-laravel": "^0.5.1",
         "illuminate/support": "^8.0|^9.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "hammerstone/sidecar": "^0.3.9",
-        "inertiajs/inertia-laravel": "^0.5.1",
+        "inertiajs/inertia-laravel": "^0.5.1|^0.6.0",
         "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {


### PR DESCRIPTION
Currently the Sidecar version is locked at `v0.3.9`, while the latest version is `v0.3.12`, this updates the requirement to `^0.3.9`
The `inertiajs/inertia-laravel` requirement is also updated to allow for versions `0.6.x` as it currently only allows `^0.5.1`